### PR TITLE
don't modify userAccountControl in User#change_password

### DIFF
--- a/lib/active_directory/user.rb
+++ b/lib/active_directory/user.rb
@@ -122,7 +122,7 @@ module ActiveDirectory
             now = FieldType::Timestamp.encode(Time.now)
             (password_expires_at < now)
         end
-    
+
         #
 		# Change the password for this account.
 		#
@@ -146,7 +146,6 @@ module ActiveDirectory
 				:operations => [
 					[ :replace, :lockoutTime, [ '0' ] ],
 					[ :replace, :unicodePwd, [ FieldType::Password.encode(new_password) ] ],
-					[ :replace, :userAccountControl, [ UAC_NORMAL_ACCOUNT.to_s ] ],
 					[ :replace, :pwdLastSet, [ (force_change ? '0' : '-1') ] ]
 				]
 			)
@@ -158,7 +157,7 @@ module ActiveDirectory
 		def unlock!
 			@@ldap.replace_attribute(distinguishedName, :lockoutTime, ['0'])
 		end
-		
+
 		#
 		# Locks this account.
 		#


### PR DESCRIPTION
Do you know why userAccountControl is being set to NORMAL_ACCOUNT in change_password?  Can't we just leave it at whatever value it already is?

In our ActiveDirectory, the UAC_NORMAL_USER value is insufficient.  We also need a higher bit set to flag that the password doesn't expire.

This page has all the possible values for userAccountControl:
http://msdn.microsoft.com/en-us/library/windows/desktop/ms680832(v=vs.85).aspx

Some of those flags mark things like: the account is disabled, the account is locked out, and the password is expired.  So, setting userAccountControl to the normal account value unsets those bits, but also unsets unrelated bits.  Maybe change_password should just unset those three flags?

I was thinking about writing a method to set all these various flags, and perhaps adding an optional hash of flags to the change_password method.

Your guidance on this would be appreciated.

Thanks,

Michael Gee
