### PR TITLE
Add seach scope and fixed search base

### DIFF
--- a/lib/active_directory/base.rb
+++ b/lib/active_directory/base.rb
@@ -244,7 +244,7 @@ module ActiveDirectory
 
             options[:filter]     = given_filter.blank? ? NIL_FILTER : given_filter
             options[:attributes] = Array.new
-            options[:in]         = ''
+            options[:in]       ||= ''
             options[:scope]    ||= Net::LDAP::SearchScope_WholeSubtree
 
             if options[:filter].is_a? Hash


### PR DESCRIPTION
Base.find now allows a :scope option (for single or multilevel searches) and the :in option is now used as the search base.
