### PR TITLE
Require ruby-net-ldap 0.5.0 to avoid encoding issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-*** Coming Soon:  I'm reworking this gem to allow simulatneous and multiple connections. Also, I'll be adding RSpec test units for all the methods.  Stay tuned!***
-
 = Active Directory
 
 Ruby Integration with Microsoft's Active Directory system based on original code by Justin Mecham and James Hunt at http://rubyforge.org/projects/activedirectory
@@ -13,8 +11,11 @@ Queries for membership and group membership are based on the distinguished name 
 <h3>INSTALL (with Bundler for instance)</h3>
 In Gemfile:
 <pre>
+gem 'net-ldap', :git => 'git://github.com/ruby-ldap/ruby-net-ldap.git'
 gem 'active_directory', :git => 'git://github.com/richardun/active_directory.git'
 </pre>
+
+Note: You'll need to install ruby-net-ldap from GitHub until the maintainer pushes version 0.5.0 or later to rubygems.org.
 
 Run bundle install: <em> :; is my prompt </em>
 <pre>

--- a/active_directory.gemspec
+++ b/active_directory.gemspec
@@ -53,12 +53,12 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<net-ldap>, [">= 0.1.1"])
+      s.add_runtime_dependency(%q<net-ldap>, [">= 0.5.0"])
     else
-      s.add_dependency(%q<net-ldap>, [">= 0.1.1"])
+      s.add_dependency(%q<net-ldap>, [">= 0.5.0"])
     end
   else
-    s.add_dependency(%q<net-ldap>, [">= 0.1.1"])
+    s.add_dependency(%q<net-ldap>, [">= 0.5.0"])
   end
 end
 


### PR DESCRIPTION
Note this pull request breaks normal installs as it requires ruby-net-ldap v0.5.0 or later which has not been pushed to rubygems.org.

There's an issue open about this and I e-mailed the author in the hopes they can put the already tagged 0.5.0 in rubygems.org.

In particular, the encoding issues at hand prevent search by GUID from working properly. Querying and saving the GUID is important to avoid problems where administrators may rename containers, etc. Querying by name is not reliable in those cases.
